### PR TITLE
Don't import Bugsnag in test build

### DIFF
--- a/app/initializers/ember-cli-bugsnag.js
+++ b/app/initializers/ember-cli-bugsnag.js
@@ -1,4 +1,3 @@
-import Ember  from 'ember';
 import config from '../config/environment';
 import Bugsnag from 'bugsnag';
 
@@ -7,7 +6,7 @@ import BugsnagConfiguration from 'ember-cli-bugsnag/utils/bugsnag-configuration'
 export default {
   name: 'ember-cli-bugsnag',
 
-  initialize: function(instance) {
+  initialize: function(/* instance */) {
     let configVariables = config.bugsnag;
     new BugsnagConfiguration(configVariables).apply(Bugsnag);
   }

--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -1,6 +1,6 @@
 import Ember  from 'ember';
 import config from '../config/environment';
-import { getContext, generateError } from 'ember-cli-bugsnag/utils/errors';
+import { getContext } from 'ember-cli-bugsnag/utils/errors';
 import { getMetaData } from '../utils/bugsnag';
 import Bugsnag from 'bugsnag';
 

--- a/app/utils/bugsnag.js
+++ b/app/utils/bugsnag.js
@@ -1,3 +1,3 @@
-export function getMetaData(error, container) {
+export function getMetaData(/* error, container */) {
   return {};
 }

--- a/index.js
+++ b/index.js
@@ -12,16 +12,29 @@ module.exports = {
     }
   },
 
+  treeForAddon: function() {
+    if (this._includeBugsnag) {
+      return this._super.treeForAddon.apply(this, arguments);
+    }
+  },
+
+  treeForApp: function() {
+    if (this._includeBugsnag) {
+      return this._super.treeForApp.apply(this, arguments);
+    }
+  },
+
   included: function(app) {
     this._super.included(app);
-
-    app.import(app.bowerDirectory + '/bugsnag/src/bugsnag.js');
-
-    app.import('vendor/bugsnag/shim.js', {
-      type: 'vendor',
-      exports: {
-        'bugsnag': ['default']
-      }
-    });
+    this._includeBugsnag = this.isDevelopingAddon() || process.env.EMBER_ENV !== 'test';
+    if (this._includeBugsnag) {
+      app.import(app.bowerDirectory + '/bugsnag/src/bugsnag.js');
+      app.import('vendor/bugsnag/shim.js', {
+        type: 'vendor',
+        exports: {
+          'bugsnag': ['default']
+        }
+      });
+    }
   }
 };


### PR DESCRIPTION
Approach:

Detect when the host app is in testing and basically make the addon enter stealth mode. Nothing is included in the app/vendor (bugsnag, initializers... nothing)