### PR TITLE
Don't include bugsnag.js in fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,10 @@ module.exports = {
   },
 
   included: function(app) {
-    this._includeBugsnag = this.isDevelopingAddon() || process.env.EMBER_ENV !== 'test';
-    this._super.included.apply(this, arguments);
+    this._includeBugsnag = process.env.EMBER_CLI_FASTBOOT !== 'true' && (
+      this.isDevelopingAddon() || process.env.EMBER_ENV !== 'test');
 
+    this._super.included.apply(this, arguments);
     if (this._includeBugsnag) {
       app.import('vendor/bugsnag/shim.js', {
         type: 'vendor',


### PR DESCRIPTION
This depends on merging #62.

Partial fix #59. This only removes the bugsnag.js from being executed in fastboot, which was preventing the app to boot. 