### PR TITLE
Remove reference to library url in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Configuration options:
  * `config.bugsnag.notifyReleaseStages` / `BUGSNAG_NOTIFY_RELEASE` -- optional, defaults to `[]` (never notify)
  * `config.bugsnag.releaseStage` / `BUGSNAG_RELEASE_STAGE` -- optional, defaults to `config.environment`
  * `config.bugsnag.endpoint` / `BUGSNAG_ENDPOINT` -- optional, defaults to what the libraryUrl uses
- * `config.bugsnag.libraryUrl` / `BUGSNAG_LIBRARY_URL` -- optional, defaults to `'https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js'`. If you want to lock to a particular version of the Bugsnag reporter, you can set this to, e.g. `'//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.4.8.min.js'`. See [Bugsnag: Advanced Hosting](https://bugsnag.com/docs/notifiers/js#advanced-hosting)
  * `config.currentRevision` -- any string representing the current version of the app, e.g. `"1b8ef2c7"` or `"v1.2.4"`, optional. [ember-git-version](https://github.com/rwjblue/ember-git-version) provides this automatically.
 
 ## Customization


### PR DESCRIPTION
It looks like this was dropped in previous iterations and we forgot to remove it from the docs.

Fixes #66. @jeffjewiss thanks for spotting, is this what you had in mind?