### PR TITLE
Fix app version

### DIFF
--- a/app/initializers/ember-cli-bugsnag.js
+++ b/app/initializers/ember-cli-bugsnag.js
@@ -9,6 +9,10 @@ export default {
   initialize: function() {
     let configVariables = config.bugsnag || {};
     let releaseStage = config.bugsnag.releaseStage || config.environment;
+
+    // Set currentRevision value as Bugsnag appVersion
+    configVariables.appVersion = config.currentRevision;
+
     new BugsnagConfiguration(configVariables, releaseStage).apply(Bugsnag);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-bugsnag",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Integrates Bugsnag reporting service into your Ember CLI app.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Hi, I've found a bug with the Bugsnag `appVersion` value.
Since the Bugsnag script was not being added to the DOM via `<script>`, the attribute `data-appVersion` was missing.

With change, the value of `currentRevision` config var is correctly setted in `window.Bugsnag.appVersion`.