### PR TITLE
Fallback to the default app version

### DIFF
--- a/app/initializers/ember-cli-bugsnag.js
+++ b/app/initializers/ember-cli-bugsnag.js
@@ -11,7 +11,7 @@ export default {
     let releaseStage = config.bugsnag.releaseStage || config.environment;
 
     // Set currentRevision value as Bugsnag appVersion
-    configVariables.appVersion = config.currentRevision;
+    configVariables.appVersion = config.currentRevision || config.APP.version;
 
     new BugsnagConfiguration(configVariables, releaseStage).apply(Bugsnag);
   }


### PR DESCRIPTION
Setting the currentVersion is a little inconvenient, and ember cli sets the version for you. This way you can fallback to the version that ember-cli sets for you based off the package.json version. 
